### PR TITLE
Include <unistd.h> in header.cpp

### DIFF
--- a/header.cpp
+++ b/header.cpp
@@ -4,6 +4,7 @@
 #include <sys/sysctl.h>
 #endif
 #include <cassert>
+#include <unistd.h>
 #include "header.h"
 
 void normalize(double *tmp,size_t len){


### PR DESCRIPTION
Between versions 1.9 and 1.10, htslib headers no longer includes <unistd.h>.  It is needed in header.cpp because of sysconf() and its lack is no longer covered up by htslib.